### PR TITLE
Disable blink-matching-paren for improvement

### DIFF
--- a/anzu.el
+++ b/anzu.el
@@ -387,6 +387,7 @@
 
 (defun anzu--read-from-string (prompt beg end use-regexp overlay-limit)
   (let ((curbuf (current-buffer))
+        (blink-matching-paren nil)
         timer is-input)
     (unwind-protect
         (minibuffer-with-setup-hook


### PR DESCRIPTION
Replacement ')' is too slow if blink-matching-paren is enabled.
It is enabled in emacs standard replace commands such as query-replace.
While it is disabled in isearch-command. I thinks it is also disabled
in replace command.