### PR TITLE
Fix matching a literal string

### DIFF
--- a/anzu.el
+++ b/anzu.el
@@ -557,7 +557,7 @@
 (defsubst anzu--replaced-literal-string (ov replaced from)
   (let ((str (buffer-substring-no-properties
               (overlay-start ov) (overlay-end ov))))
-    (when (string-match str from)
+    (when (string-match (regexp-quote str) from)
       (replace-match replaced (not case-fold-search) nil str))))
 
 (defun anzu--append-replaced-string (content buf beg end use-regexp overlay-limit from)


### PR DESCRIPTION
置換する文字列に`[]`が含まれている場合にエラーが発生する問題を修正。

**再現例**

1. バッファ中に文字列 `[]` が一つ以上ある状態で M-x `anzu-query-replace` [Enter]
2. Query replace: `[]` [Enter]
3. Query replace [] with: (何か文字を入力)
4. `Error running timer: (invalid-regexp "Unmatched [ or [^")`
