### PR TITLE
Fix literal replace

### DIFF
--- a/anzu.el
+++ b/anzu.el
@@ -561,7 +561,7 @@
   (let ((str (buffer-substring-no-properties
               (overlay-start ov) (overlay-end ov))))
     (when (string-match (regexp-quote str) from)
-      (replace-match replaced (not case-fold-search) nil str))))
+      (replace-match replaced (not case-fold-search) t str))))
 
 (defun anzu--append-replaced-string (content buf beg end use-regexp overlay-limit from)
   (let ((replacements 0))


### PR DESCRIPTION
replace-match: third argument requires non-nil, if replace literally.

Example:

1. Set buffer include "/" characters
2. M-x anzu-query-replace RET
3. Query replace : / RET
4. Query replace / with: \
    -> ```Error running timer: (error "Invalid use of `\\' in replacement text")```