### PR TITLE
Fix invalid regexp in migemo

### DIFF
--- a/anzu.el
+++ b/anzu.el
@@ -207,7 +207,10 @@
                                'migemo-forward
                              're-search-forward))
               (case-fold-search (anzu--case-fold-search input)))
-          (while (and (not finish) (funcall search-func input nil t))
+          (while (and (not finish)
+                      (condition-case nil
+                          (funcall search-func input nil t)
+                        (invalid-regexp nil)))
             (push (cons (match-beginning 0) (match-end 0)) positions)
             (cl-incf count)
             (when (= (match-beginning 0) (match-end 0)) ;; Case of anchor such as "^"


### PR DESCRIPTION
When `anzu-use-migemo` is non-nil, Type "C-s [" are thrown error with
invalid regexp.

```
(migemo-forward "\\[" nil t)     ;* invalid-regexp
(re-search-forward "\\[" nil t)  ;=> nil
```