### PR TITLE
Silence byte-compiler

### DIFF
--- a/anzu.el
+++ b/anzu.el
@@ -39,6 +39,8 @@
 (require 'cl-lib)
 (require 'thingatpt)
 
+(declare-function migemo-forward 'migemo)
+
 (defgroup anzu nil
   "Show searched position in mode-line"
   :group 'isearch)


### PR DESCRIPTION
The call to `migemo-forward` is already wrapped with `ignore-errors` - maybe you meant to use `with-no-warnings`?