### PR TITLE
Fix word replace in region

### DIFF
--- a/anzu.el
+++ b/anzu.el
@@ -661,9 +661,9 @@
       (point-max))))
 
 (defun anzu--region-begin (use-region thing backward)
-  (cond (current-prefix-arg (line-beginning-position))
+  (cond (use-region (region-beginning))
+        (current-prefix-arg (line-beginning-position))
         (thing (anzu--thing-begin thing))
-        (use-region (region-beginning))
         (backward (point-min))
         (t (point))))
 
@@ -673,10 +673,10 @@
     (line-end-position)))
 
 (defun anzu--region-end (use-region thing)
-  (cond (current-prefix-arg
+  (cond (use-region (region-end))
+        (current-prefix-arg
          (anzu--line-end-position (prefix-numeric-value current-prefix-arg)))
         (thing (anzu--thing-end thing))
-        (use-region (region-end))
         (t (point-max))))
 
 (defun anzu--begin-thing (at-cursor thing)


### PR DESCRIPTION
anzu.elを愛用させてもらっています。
ひさしぶりに更新したところ、選択範囲内の単語置換が効かなくなっていて
昔のバージョンと見比べながら、この変更で直ったのですが、あっているかわかりません。
確認お願いいたします。
