### PR TITLE
Change syntax for bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Same as `query-replace-regexp` except anzu information in mode-line
 Add following S-exp in your configuration if you want to use anzu's replace commands by default.
 
 ```lisp
-(global-set-key (kbd "M-%") 'anzu-query-replace)
-(global-set-key (kbd "C-M-%") 'anzu-query-replace-regexp)
+(global-set-key [remap query-replace] 'anzu-query-replace)
+(global-set-key [remap query-replace-regexp] 'anzu-query-replace-regexp)
 ```
 
 [anzu-replace-demo](image/anzu-replace-demo.gif)


### PR DESCRIPTION
Instead of overriding the keys, suggest to remap the commands which remaps the commands everywhere (e.g. also in the menu bar) and creates nicer docstrings (the docstring of `query-replace` will still show its default bindings, indicating that they were remapped to `anzu-query-replace`).